### PR TITLE
Add README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# You Should Draw
+
+You Should Draw is a small PHP application that generates random character drawing prompts. It pulls information from a MySQL database and combines different options to present unique ideas every time you click **Next Idea**. A simple CRUD interface is included so you can add or edit the options available.
+
+## Requirements
+
+* PHP 7.x or later with MySQL extensions
+* MySQL server
+
+## Database Schema
+
+Two tables are required: `drawoptions` which stores the values used to build prompts, and `adminuser` for a simple password protected CRUD page.
+
+Example schema:
+
+```sql
+CREATE TABLE `drawoptions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `type` varchar(50) NOT NULL,
+  PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `adminuser` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `password` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+);
+```
+
+The values in `drawoptions.type` correspond to options like `Base Class`, `Major Feature`, `Accessories`, `Emotion` and `Pet`.
+
+## Database Connection
+
+Create a file `includes/dbcon.php` in the project root with your database credentials:
+
+```php
+<?php
+$servername = getenv('YSD_DB_HOST') ?: 'localhost';
+$username   = getenv('YSD_DB_USER');
+$password   = getenv('YSD_DB_PASS');
+$dbname     = getenv('YSD_DB_NAME');
+```
+
+You can either fill in the variables directly or set the environment variables `YSD_DB_HOST`, `YSD_DB_USER`, `YSD_DB_PASS` and `YSD_DB_NAME` to keep credentials out of the codebase.
+
+## Usage
+
+1. Place the project files in a directory served by PHP.
+2. Start a development server from the project root:
+   ```bash
+   php -S localhost:8000
+   ```
+3. Navigate to `http://localhost:8000/index.php` in your browser to generate drawing prompts.
+
+The administrative tool for modifying options is `crud.php` and can be accessed the same way when you need to add or change prompt choices.


### PR DESCRIPTION
## Summary
- document the app with a new README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407a2516248327a164055eb9fb95b3