### PR TITLE
Add SQLite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # You Should Draw
 
-You Should Draw is a small PHP application that generates random character drawing prompts. It pulls information from a MySQL database and combines different options to present unique ideas every time you click **Next Idea**. A simple CRUD interface is included so you can add or edit the options available.
+You Should Draw is a small PHP application that generates random character drawing prompts. It pulls information from a MySQL or SQLite database and combines different options to present unique ideas every time you click **Next Idea**. A simple CRUD interface is included so you can add or edit the options available.
 
 ## Requirements
 
-* PHP 7.x or later with MySQL extensions
-* MySQL server
+* PHP 7.x or later with PDO and either the MySQL or SQLite extensions
+* MySQL server or SQLite
 
 ## Database Schema
 
@@ -32,17 +32,30 @@ The values in `drawoptions.type` correspond to options like `Base Class`, `Major
 
 ## Database Connection
 
-Create a file `includes/dbcon.php` in the project root with your database credentials:
+Create a file `includes/dbcon.php` in the project root that provides a `getPDO()` function returning a PDO connection. For a MySQL setup:
 
 ```php
 <?php
-$servername = getenv('YSD_DB_HOST') ?: 'localhost';
-$username   = getenv('YSD_DB_USER');
-$password   = getenv('YSD_DB_PASS');
-$dbname     = getenv('YSD_DB_NAME');
+function getPDO() {
+    $host = getenv('YSD_DB_HOST') ?: 'localhost';
+    $user = getenv('YSD_DB_USER');
+    $pass = getenv('YSD_DB_PASS');
+    $db   = getenv('YSD_DB_NAME');
+    return new PDO("mysql:host=$host;dbname=$db;charset=utf8mb4", $user, $pass);
+}
 ```
 
-You can either fill in the variables directly or set the environment variables `YSD_DB_HOST`, `YSD_DB_USER`, `YSD_DB_PASS` and `YSD_DB_NAME` to keep credentials out of the codebase.
+To use SQLite instead:
+
+```php
+<?php
+function getPDO() {
+    $path = getenv('YSD_DB_PATH') ?: __DIR__ . '/../ysd.sqlite';
+    return new PDO('sqlite:' . $path);
+}
+```
+
+Environment variables (`YSD_DB_HOST`, `YSD_DB_USER`, `YSD_DB_PASS`, `YSD_DB_NAME` or `YSD_DB_PATH`) keep credentials out of the codebase.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- switch DB code to PDO
- support MySQL or SQLite via configuration
- document new PDO-based configuration

## Testing
- `php -l grabinfo.php`
- `php -l crud.php`


------
https://chatgpt.com/codex/tasks/task_e_68407de1dde88327a088cabf1ff1868f