### PR TITLE
Add theme sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ CREATE TABLE `drawoptions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `type` varchar(50) NOT NULL,
+  `theme` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`id`)
 );
 
@@ -29,6 +30,11 @@ CREATE TABLE `adminuser` (
 ```
 
 The values in `drawoptions.type` correspond to options like `Base Class`, `Major Feature`, `Accessories`, `Emotion` and `Pet`.
+The optional `theme` column lets you group options into sets (for example `Sci-Fi`, `Medieval` or `Cute`). Existing installations can add the column with:
+
+```sql
+ALTER TABLE `drawoptions` ADD `theme` varchar(50) DEFAULT NULL;
+```
 
 ## Database Connection
 

--- a/crud.php
+++ b/crud.php
@@ -32,12 +32,16 @@ $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 //DISPLAY VALUES
 
-$currdbsql = "SELECT name,type FROM drawoptions";
+$currdbsql = "SELECT name,type,theme FROM drawoptions";
 $stmt = $pdo->query($currdbsql);
 $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 if ($rows) {
      foreach ($rows as $row) {
-         echo htmlspecialchars($row['name']) . " - " . htmlspecialchars($row['type']) . "<br />";
+         echo htmlspecialchars($row['name']) . " - " . htmlspecialchars($row['type']);
+         if (!empty($row['theme'])) {
+             echo " (" . htmlspecialchars($row['theme']) . ")";
+         }
+         echo "<br />";
      }
 } else {
      echo "Zero results";
@@ -56,6 +60,11 @@ if (!empty($_POST)) {
         if ($type === null) {
                 $type = '';
                 echo "Invalid element type provided.<br />";
+        }
+
+        $theme = filter_input(INPUT_POST, "elementtheme", FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        if ($theme === null) {
+                $theme = '';
         }
 
         $password = filter_input(INPUT_POST, "elementpassword", FILTER_SANITIZE_FULL_SPECIAL_CHARS);
@@ -77,8 +86,8 @@ if (!empty($_POST)) {
 
 		$_SESSION["loginaccepted"] = "true";
 		
-                $stmt = $pdo->prepare("INSERT INTO drawoptions (name, type) VALUES (:name, :type)");
-                if ($stmt->execute([':name' => $name, ':type' => $type])) {
+                $stmt = $pdo->prepare("INSERT INTO drawoptions (name, type, theme) VALUES (:name, :type, :theme)");
+                if ($stmt->execute([':name' => $name, ':type' => $type, ':theme' => $theme])) {
                         echo "New record created successfully";
                 } else {
                         echo "Error: " . implode(' ', $stmt->errorInfo());
@@ -96,13 +105,14 @@ if (!empty($_POST)) {
 <form method="post" action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>">
 Element Name: <input name="elementname" type="text" id="ename"><br />
 Element Type: <select name="elementtype" type="text" id="etype">
-				<option value="Base Class">Base Class</option>
-				<option value="Major Feature">Major Feature</option>
-				<option value="Accessories">Accessory</option>
-				<option value="Emotion">Emotion</option>
-				<option value="Pet">Pet</option>
-			</select>
+                                <option value="Base Class">Base Class</option>
+                                <option value="Major Feature">Major Feature</option>
+                                <option value="Accessories">Accessory</option>
+                                <option value="Emotion">Emotion</option>
+                                <option value="Pet">Pet</option>
+                        </select>
 <br />
+Theme: <input name="elementtheme" type="text" id="etheme"><br />
 <?php if ( !isset($_SESSION["loginaccepted"]) ) {?>
 Password: <input name="elementpassword" type="password" id="pw"><br />
 <?php } ?>

--- a/grabinfo.php
+++ b/grabinfo.php
@@ -6,6 +6,7 @@ if($_POST){
         $emotion = filter_input(INPUT_POST, 'emotion', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
         $pet = filter_input(INPUT_POST, 'pet', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
         $accessories = filter_input(INPUT_POST, 'accessories', FILTER_VALIDATE_INT);
+        $theme = filter_input(INPUT_POST, 'theme', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
         if ($accessories === false || $accessories === null) {
                 echo "Invalid accessories value. Defaulting to 1.<br />";
                 $accessories = 1;
@@ -37,32 +38,70 @@ if($_POST){
         $driver = $pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
         $rand = ($driver === 'sqlite') ? 'RANDOM()' : 'RAND()';
 	
-        $stmt = $pdo->prepare("SELECT name FROM drawoptions WHERE type = :type ORDER BY $rand LIMIT 1");
-        $stmt->execute([':type' => 'Base Class']);
+        $query = "SELECT name FROM drawoptions WHERE type = :type";
+        $params = [':type' => 'Base Class'];
+        if (!empty($theme)) {
+                $query .= " AND theme = :theme";
+                $params[':theme'] = $theme;
+        }
+        $query .= " ORDER BY $rand LIMIT 1";
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
         $baseclass_output = $stmt->fetchColumn();
 
-        $stmt = $pdo->prepare("SELECT name FROM drawoptions WHERE type = :type ORDER BY $rand LIMIT 1");
-        $stmt->execute([':type' => 'Major Feature']);
+        $query = "SELECT name FROM drawoptions WHERE type = :type";
+        $params = [':type' => 'Major Feature'];
+        if (!empty($theme)) {
+                $query .= " AND theme = :theme";
+                $params[':theme'] = $theme;
+        }
+        $query .= " ORDER BY $rand LIMIT 1";
+        $stmt = $pdo->prepare($query);
+        $stmt->execute($params);
         $majorfeature_output = $stmt->fetchColumn();
 	
 	if (!$accessories){
 		$accessories = 1;
 	}
 	
-        $stmt = $pdo->prepare("SELECT name FROM drawoptions WHERE type = 'Accessories' ORDER BY $rand LIMIT :lim");
+        $query = "SELECT name FROM drawoptions WHERE type = 'Accessories'";
+        $params = [];
+        if (!empty($theme)) {
+                $query .= " AND theme = :theme";
+                $params[':theme'] = $theme;
+        }
+        $query .= " ORDER BY $rand LIMIT :lim";
+        $stmt = $pdo->prepare($query);
         $stmt->bindValue(':lim', (int)$accessories, PDO::PARAM_INT);
+        foreach ($params as $k => $v) {
+                $stmt->bindValue($k, $v);
+        }
         $stmt->execute();
         $accessory_output = $stmt->fetchAll(PDO::FETCH_COLUMN);
 	
-	if (isset($emotion)){
-                $stmt = $pdo->prepare("SELECT name FROM drawoptions WHERE type = :type ORDER BY $rand LIMIT 1");
-                $stmt->execute([':type' => 'Emotion']);
+        if (isset($emotion)){
+                $query = "SELECT name FROM drawoptions WHERE type = :type";
+                $params = [':type' => 'Emotion'];
+                if (!empty($theme)) {
+                        $query .= " AND theme = :theme";
+                        $params[':theme'] = $theme;
+                }
+                $query .= " ORDER BY $rand LIMIT 1";
+                $stmt = $pdo->prepare($query);
+                $stmt->execute($params);
                 $emotion_output = $stmt->fetchColumn();
         }
 
         if (isset($pet)){
-                $stmt = $pdo->prepare("SELECT name FROM drawoptions WHERE type = :type ORDER BY $rand LIMIT 1");
-                $stmt->execute([':type' => 'Pet']);
+                $query = "SELECT name FROM drawoptions WHERE type = :type";
+                $params = [':type' => 'Pet'];
+                if (!empty($theme)) {
+                        $query .= " AND theme = :theme";
+                        $params[':theme'] = $theme;
+                }
+                $query .= " ORDER BY $rand LIMIT 1";
+                $stmt = $pdo->prepare($query);
+                $stmt->execute($params);
                 $pet_output = $stmt->fetchColumn();
         }
 

--- a/index.php
+++ b/index.php
@@ -1,3 +1,34 @@
+<?php
+$config = __DIR__ . '/includes/dbcon.php';
+if (file_exists($config)) {
+    require $config;
+}
+
+if (function_exists('getPDO')) {
+    $pdo = getPDO();
+} else {
+    $type = getenv('YSD_DB_TYPE') ?: 'mysql';
+    if ($type === 'sqlite') {
+        $path = getenv('YSD_DB_PATH') ?: __DIR__ . '/ysd.sqlite';
+        $pdo = new PDO('sqlite:' . $path);
+    } else {
+        $host = getenv('YSD_DB_HOST') ?: 'localhost';
+        $user = getenv('YSD_DB_USER');
+        $pass = getenv('YSD_DB_PASS');
+        $dbname = getenv('YSD_DB_NAME');
+        $dsn = "mysql:host=$host;dbname=$dbname;charset=utf8mb4";
+        $pdo = new PDO($dsn, $user, $pass);
+    }
+}
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$themes = [];
+try {
+    $stmt = $pdo->query("SELECT DISTINCT theme FROM drawoptions WHERE theme IS NOT NULL AND theme != '' ORDER BY theme");
+    $themes = $stmt->fetchAll(PDO::FETCH_COLUMN);
+} catch (Exception $e) {
+    $themes = [];
+}
+?>
 <!doctype html>
 <html lang="en">
 <head>
@@ -86,6 +117,13 @@ document.addEventListener('DOMContentLoaded', function() {
 <div class="left_side"><input type="checkbox" name="gender" id="gender" value="Gender">Random Gender?<br />
 <input type="checkbox" name="emotion" id="emotion" value="Emotion">Random Emotion?<br />
 <input type="checkbox" name="pet" id="pet" value="Pet">Random Pet?</br>
+<label for="themeSelect">Theme:</label>
+<select name="theme" id="themeSelect">
+<option value="">Any Theme</option>
+<?php foreach ($themes as $t): ?>
+<option value="<?php echo htmlspecialchars($t); ?>"><?php echo htmlspecialchars($t); ?></option>
+<?php endforeach; ?>
+</select><br />
 </div>
 <div class="right_side">
 <input type="radio" name="accessories" class="accessories" value="1" checked>One Accessory<br />


### PR DESCRIPTION
## Summary
- add `theme` column to the schema and document updating existing DBs
- load available themes in `index.php` and add a theme selector
- restrict randomizer queries by the chosen theme
- allow CRUD UI to view and set themes when creating options

## Testing
- `php -l index.php`
- `php -l grabinfo.php`
- `php -l crud.php`


------
https://chatgpt.com/codex/tasks/task_e_6840831d8ad08327a901dec4fcf03629