### PR TITLE
Add prompt sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ CREATE TABLE `adminuser` (
   `password` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 );
+
+CREATE TABLE `generated_prompts` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `base_class_id` int(11) NOT NULL,
+  `major_feature_id` int(11) NOT NULL,
+  `accessory1_id` int(11) DEFAULT NULL,
+  `accessory2_id` int(11) DEFAULT NULL,
+  `accessory3_id` int(11) DEFAULT NULL,
+  `emotion_id` int(11) DEFAULT NULL,
+  `pet_id` int(11) DEFAULT NULL,
+  `prompt` text NOT NULL,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+);
 ```
 
 The values in `drawoptions.type` correspond to options like `Base Class`, `Major Feature`, `Accessories`, `Emotion` and `Pet`.
@@ -82,4 +96,19 @@ A simple JSON endpoint is available at `/api/getidea`. It accepts the same query
 $ curl 'http://localhost:8000/api/getidea'
 {"prompt":"You should draw ..."}
 ```
+
+Each response also includes an `id` field which can be used to share the prompt:
+`share.php?id=<ID>` will display the stored text.
+
+## Sharing Prompts
+
+Whenever a prompt is generated (through the website or the API) it is stored in
+the `generated_prompts` table. The ID of the saved row is returned to the
+frontend so you can share a direct link such as:
+
+```
+http://localhost:8000/share.php?id=123
+```
+
+Opening that URL will show the exact text that was generated.
 

--- a/share.php
+++ b/share.php
@@ -1,0 +1,45 @@
+<?php
+$config = __DIR__ . '/includes/dbcon.php';
+if (file_exists($config)) {
+    require $config;
+}
+if (function_exists('getPDO')) {
+    $pdo = getPDO();
+} else {
+    $type = getenv('YSD_DB_TYPE') ?: 'mysql';
+    if ($type === 'sqlite') {
+        $path = getenv('YSD_DB_PATH') ?: __DIR__ . '/ysd.sqlite';
+        $pdo = new PDO('sqlite:' . $path);
+    } else {
+        $host = getenv('YSD_DB_HOST') ?: 'localhost';
+        $user = getenv('YSD_DB_USER');
+        $pass = getenv('YSD_DB_PASS');
+        $dbname = getenv('YSD_DB_NAME');
+        $dsn = "mysql:host=$host;dbname=$dbname;charset=utf8mb4";
+        $pdo = new PDO($dsn, $user, $pass);
+    }
+}
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+$stmt = $pdo->prepare('SELECT prompt FROM generated_prompts WHERE id = ?');
+$stmt->execute([$id]);
+$prompt = $stmt->fetchColumn();
+if (!$prompt) {
+    http_response_code(404);
+    echo 'Prompt not found';
+    exit;
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>You Should Draw - Shared Prompt</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h3 class="main"><?php echo htmlspecialchars($prompt); ?></h3>
+<div class="share"><a href="index.php">Generate your own idea</a></div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- store generated prompts in a `generated_prompts` table
- return the saved ID from the API and HTML generator
- add a share page to show a saved prompt
- document sharing prompts in README

## Testing
- `php -l grabinfo.php`
- `php -l api/getidea.php`
- `php -l share.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_684088d80fd083279aab410b1413e29a