### PR TITLE
Enable prettier share URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^share/([0-9]+)$ share.php?id=$1 [L,QSA]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ curl 'http://localhost:8000/api/getidea'
 ```
 
 Each response also includes an `id` field which can be used to share the prompt:
-`share.php?id=<ID>` will display the stored text.
+`/share/<ID>` will display the stored text.
 
 ## Sharing Prompts
 
@@ -107,7 +107,7 @@ the `generated_prompts` table. The ID of the saved row is returned to the
 frontend so you can share a direct link such as:
 
 ```
-http://localhost:8000/share.php?id=123
+http://localhost:8000/share/123
 ```
 
 Opening that URL will show the exact text that was generated.

--- a/grabinfo.php
+++ b/grabinfo.php
@@ -169,5 +169,5 @@ $stmt = $pdo->prepare("INSERT INTO generated_prompts (base_class_id, major_featu
 $stmt->execute([$baseclass['id'], $majorfeature['id'], $acc1, $acc2, $acc3, $emotion_id, $pet_id, $prompt]);
 $share_id = $pdo->lastInsertId();
 
-echo htmlspecialchars($prompt) . '<br /><a href="share.php?id=' . $share_id . '">Share this prompt</a>';
+echo htmlspecialchars($prompt) . '<br /><a href="share/' . $share_id . '">Share this prompt</a>';
 

--- a/share.php
+++ b/share.php
@@ -21,6 +21,12 @@ if (function_exists('getPDO')) {
 }
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+if (!$id && isset($_SERVER['REQUEST_URI'])) {
+    $path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    if (preg_match('#/share/([0-9]+)#', $path, $m)) {
+        $id = (int)$m[1];
+    }
+}
 $stmt = $pdo->prepare('SELECT prompt FROM generated_prompts WHERE id = ?');
 $stmt->execute([$id]);
 $prompt = $stmt->fetchColumn();


### PR DESCRIPTION
## Summary
- add rewrite rule for friendly `/share/<id>` URLs
- parse shared IDs from the request URI
- update link generation and docs to use the new permalinks

## Testing
- `php -l share.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408a24e05483279c93177b78a1714d