### PR TITLE
Prevent errors with empty DB

### DIFF
--- a/api/getidea.php
+++ b/api/getidea.php
@@ -52,6 +52,11 @@ function randomRow($pdo, $type, $theme, $rand) {
 $baseclass = randomRow($pdo, 'Base Class', $theme, $rand);
 $majorfeature = randomRow($pdo, 'Major Feature', $theme, $rand);
 
+if (!$baseclass || !$majorfeature) {
+    echo json_encode(['error' => 'No drawing options have been added yet.']);
+    return;
+}
+
 if (!$accessories) {
     $accessories = 1;
 }
@@ -70,12 +75,17 @@ foreach ($params as $k => $v) {
 $stmt->execute();
 $accessories_rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
+if (count($accessories_rows) === 0) {
+    echo json_encode(['error' => 'No drawing options have been added yet.']);
+    return;
+}
+
 if (isset($emotion)) {
-    $emotion_row = randomRow($pdo, 'Emotion', $theme, $rand);
+    $emotion_row = randomRow($pdo, 'Emotion', $theme, $rand) ?: null;
 }
 
 if (isset($pet)) {
-    $pet_row = randomRow($pdo, 'Pet', $theme, $rand);
+    $pet_row = randomRow($pdo, 'Pet', $theme, $rand) ?: null;
 }
 
 $vowels = ['A','E','I','O','U'];
@@ -84,10 +94,10 @@ function articleFor($word, $vowels){
 }
 
 $prompt = 'You should draw ';
-if (isset($emotion)) {
+if (isset($emotion) && $emotion_row) {
     $prompt .= articleFor($emotion_row['name'], $vowels) . $emotion_row['name'] . ' ';
 }
-if (!isset($emotion)) {
+if (!isset($emotion) || !$emotion_row) {
     $prompt .= articleFor($majorfeature['name'], $vowels);
 }
 $prompt .= $majorfeature['name'] . ' ';
@@ -119,7 +129,7 @@ for ($i=0; $i<count($accessories_rows); $i++) {
     }
     $prompt .= $accessories_rows[$i]['name'];
 }
-if (isset($pet)) {
+if (isset($pet) && $pet_row) {
     $prompt .= ' that owns ';
     if (substr($pet_row['name'], -1) != 's') {
         $prompt .= articleFor($pet_row['name'], $vowels);

--- a/grabinfo.php
+++ b/grabinfo.php
@@ -59,6 +59,14 @@ if($_POST){
         $stmt = $pdo->prepare($query);
         $stmt->execute($params);
         $majorfeature = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        // When the database is empty (or missing required types), we can't
+        // build a prompt. Instead of throwing notices, display a friendly
+        // message.
+        if (!$baseclass || !$majorfeature) {
+                echo 'No drawing options have been added yet.';
+                return;
+        }
 	
 	if (!$accessories){
 		$accessories = 1;
@@ -78,6 +86,11 @@ if($_POST){
         }
         $stmt->execute();
         $accessory_rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        if (count($accessory_rows) === 0) {
+                echo 'No drawing options have been added yet.';
+                return;
+        }
 	
         if (isset($emotion)){
                 $query = "SELECT id, name FROM drawoptions WHERE type = :type";
@@ -88,8 +101,8 @@ if($_POST){
                 }
                 $query .= " ORDER BY $rand LIMIT 1";
                 $stmt = $pdo->prepare($query);
-                $stmt->execute($params);
-                $emotion_row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->execute($params);
+        $emotion_row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
         }
 
         if (isset($pet)){
@@ -101,8 +114,8 @@ if($_POST){
                 }
                 $query .= " ORDER BY $rand LIMIT 1";
                 $stmt = $pdo->prepare($query);
-                $stmt->execute($params);
-                $pet_row = $stmt->fetch(PDO::FETCH_ASSOC);
+        $stmt->execute($params);
+        $pet_row = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
         }
 
 $vowels = array('A', 'E', 'I', 'O', 'U');  	


### PR DESCRIPTION
## Summary
- guard against empty tables when generating prompts
- handle missing emotion/pet rows gracefully

## Testing
- `php -l grabinfo.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841b3f89df88327b6a8d79f7efaff08