### PR TITLE
Enable extensionless API path

### DIFF
--- a/api/.htaccess
+++ b/api/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine On
+RewriteRule ^getidea$ getidea.php [L,QSA]

--- a/api/getidea/index.php
+++ b/api/getidea/index.php
@@ -1,0 +1,2 @@
+<?php
+require __DIR__ . '/../getidea.php';


### PR DESCRIPTION
## Summary
- allow calling the API without the `.php` extension
- add `.htaccess` rule so `/api/getidea` works
- create directory fallback for environments without `.htaccess`

## Testing
- `php -l api/getidea.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b6d1cdb88327a16caec7e677ad6b