### PR TITLE
Remove invalid accessories warning

### DIFF
--- a/grabinfo.php
+++ b/grabinfo.php
@@ -8,7 +8,8 @@ if($_POST){
         $accessories = filter_input(INPUT_POST, 'accessories', FILTER_VALIDATE_INT);
         $theme = filter_input(INPUT_POST, 'theme', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
         if ($accessories === false || $accessories === null) {
-                echo "Invalid accessories value. Defaulting to 1.<br />";
+                // Default to one accessory when no valid value is provided.
+                // Silently correct the value instead of displaying an error to the user.
                 $accessories = 1;
         }
 }


### PR DESCRIPTION
## Summary
- remove user-facing warning for invalid accessories value

## Testing
- `php -l grabinfo.php`
- `php -l index.php`
- `php -l crud.php`
- `php -l share.php`


------
https://chatgpt.com/codex/tasks/task_e_6841b786524c8327b0d3bc9e0a86ec1e