### PR TITLE
Deduplicate generated prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ Each response also includes an `id` field which can be used to share the prompt:
 ## Sharing Prompts
 
 Whenever a prompt is generated (through the website or the API) it is stored in
-the `generated_prompts` table. The ID of the saved row is returned to the
-frontend so you can share a direct link such as:
+the `generated_prompts` table. If the exact text already exists the previous
+record is reused, otherwise a new row is created. The returned ID lets you share
+a direct link such as:
 
 ```
 http://localhost:8000/share/123

--- a/api/getidea.php
+++ b/api/getidea.php
@@ -143,9 +143,18 @@ $acc2 = $accessories_rows[1]['id'] ?? null;
 $acc3 = $accessories_rows[2]['id'] ?? null;
 $emotion_id = isset($emotion_row) ? $emotion_row['id'] : null;
 $pet_id = isset($pet_row) ? $pet_row['id'] : null;
-$stmt = $pdo->prepare("INSERT INTO generated_prompts (base_class_id, major_feature_id, accessory1_id, accessory2_id, accessory3_id, emotion_id, pet_id, prompt) VALUES (?,?,?,?,?,?,?,?)");
-$stmt->execute([$baseclass['id'], $majorfeature['id'], $acc1, $acc2, $acc3, $emotion_id, $pet_id, $prompt]);
-$id = $pdo->lastInsertId();
+
+// Check if this exact prompt already exists and reuse the ID if so
+$stmt = $pdo->prepare('SELECT id FROM generated_prompts WHERE prompt = ? LIMIT 1');
+$stmt->execute([$prompt]);
+$existingId = $stmt->fetchColumn();
+if ($existingId) {
+    $id = $existingId;
+} else {
+    $stmt = $pdo->prepare("INSERT INTO generated_prompts (base_class_id, major_feature_id, accessory1_id, accessory2_id, accessory3_id, emotion_id, pet_id, prompt) VALUES (?,?,?,?,?,?,?,?)");
+    $stmt->execute([$baseclass['id'], $majorfeature['id'], $acc1, $acc2, $acc3, $emotion_id, $pet_id, $prompt]);
+    $id = $pdo->lastInsertId();
+}
 
 echo json_encode(['prompt' => $prompt, 'id' => $id]);
 

--- a/grabinfo.php
+++ b/grabinfo.php
@@ -174,14 +174,24 @@ if (isset($pet) && $pet_row) {
 }
 
 // store IDs
+
 $acc1 = $accessory_rows[0]['id'] ?? null;
 $acc2 = $accessory_rows[1]['id'] ?? null;
 $acc3 = $accessory_rows[2]['id'] ?? null;
 $emotion_id = $emotion_row['id'] ?? null;
 $pet_id = $pet_row['id'] ?? null;
-$stmt = $pdo->prepare("INSERT INTO generated_prompts (base_class_id, major_feature_id, accessory1_id, accessory2_id, accessory3_id, emotion_id, pet_id, prompt) VALUES (?,?,?,?,?,?,?,?)");
-$stmt->execute([$baseclass['id'], $majorfeature['id'], $acc1, $acc2, $acc3, $emotion_id, $pet_id, $prompt]);
-$share_id = $pdo->lastInsertId();
+
+// Reuse an existing prompt entry if the text matches
+$stmt = $pdo->prepare('SELECT id FROM generated_prompts WHERE prompt = ? LIMIT 1');
+$stmt->execute([$prompt]);
+$existingId = $stmt->fetchColumn();
+if ($existingId) {
+    $share_id = $existingId;
+} else {
+    $stmt = $pdo->prepare("INSERT INTO generated_prompts (base_class_id, major_feature_id, accessory1_id, accessory2_id, accessory3_id, emotion_id, pet_id, prompt) VALUES (?,?,?,?,?,?,?,?)");
+    $stmt->execute([$baseclass['id'], $majorfeature['id'], $acc1, $acc2, $acc3, $emotion_id, $pet_id, $prompt]);
+    $share_id = $pdo->lastInsertId();
+}
 
 echo htmlspecialchars($prompt) . '<br /><a href="share/' . $share_id . '">Share this prompt</a>';
 


### PR DESCRIPTION
## Summary
- reuse existing prompt IDs when the text already exists
- note deduplication in README

## Testing
- `php -l api/getidea.php`
- `php -l grabinfo.php`
- `php -l share.php`

------
https://chatgpt.com/codex/tasks/task_e_6841b8a72b2483279ebcbac6da7fb947