### PR TITLE
Add collapsing history for last five prompts

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,6 +45,7 @@ try {
   <![endif]-->
 
 <script type="text/javascript">
+let historyItems = [];
 function toggleDiv(divId) {
   const el = document.getElementById(divId);
   if (window.getComputedStyle(el).display === 'none') {
@@ -55,10 +56,24 @@ function toggleDiv(divId) {
 }
 
 function addToHistory(text) {
+  historyItems.unshift(text);
+  historyItems = historyItems.slice(0, 5);
+
+  const summary = document.getElementById('history_summary');
   const list = document.getElementById('idea_history');
-  const li = document.createElement('li');
-  li.innerHTML = text;
-  list.prepend(li);
+  list.innerHTML = '';
+
+  if (historyItems.length > 0) {
+    summary.innerHTML = historyItems[0];
+    historyItems.slice(1).forEach(item => {
+      const li = document.createElement('li');
+      li.innerHTML = item;
+      list.appendChild(li);
+    });
+    document.getElementById('history_details').style.display = 'block';
+  } else {
+    document.getElementById('history_details').style.display = 'none';
+  }
 }
 
 function fetchIdea(formData) {
@@ -127,7 +142,10 @@ document.addEventListener('DOMContentLoaded', function() {
 <button id="themeToggle" aria-label="Toggle dark mode">🌙</button>
 <button id="fontToggle" aria-label="Toggle large text">A+</button>
 <h3 id="maincontent" class="main" aria-live="polite"></h3>
-<ul id="idea_history"></ul>
+<details id="history_details" style="display:none;">
+  <summary id="history_summary"></summary>
+  <ul id="idea_history"></ul>
+</details>
 
 <div id="draw_options">
 <form method="post" id="optionsform" action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>">

--- a/style.css
+++ b/style.css
@@ -110,6 +110,19 @@ select:focus {
         margin: 10px auto;
         padding: 0;
 }
+#history_details {
+        width: 80%;
+        margin: 10px auto;
+}
+
+#history_details summary {
+        background: #fff;
+        border: 1px solid #ccc;
+        padding: 5px 10px;
+        margin-bottom: 5px;
+        cursor: pointer;
+        list-style: none;
+}
 
 #idea_history li {
         background: #fff;
@@ -122,7 +135,8 @@ select:focus {
 @media (max-width: 600px) {
         h3,
         #idea_history,
-        #draw_options {
+        #draw_options,
+        #history_details {
                 width: 95%;
         }
 
@@ -175,6 +189,11 @@ body.dark h3 {
 }
 
 body.dark #idea_history li {
+        background: #333;
+        border-color: #555;
+        color: #eee;
+}
+body.dark #history_details summary {
         background: #333;
         border-color: #555;
         color: #eee;


### PR DESCRIPTION
## Summary
- keep last five prompts on screen
- show previous prompts in a collapsible section
- style collapsible history with dark mode support

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841bbf075f0832787822bb3c0c68b13